### PR TITLE
Fix Boolean type checks in 02_data_types.py example file

### DIFF
--- a/2_predictive_stepping/examples/02_data_types.py
+++ b/2_predictive_stepping/examples/02_data_types.py
@@ -35,12 +35,13 @@ a_boolean = False
 pass_check_string = isinstance(a_string, str)
 pass_check_integer = isinstance(an_integer, int)
 pass_check_float = isinstance(a_float, float)
-pass_check_boolean = isinstance(a_boolean, bool)
+pass_check_boolean_as_bool = isinstance(a_boolean, bool)
+pass_check_boolean_as_int = isinstance(a_boolean, int) # Booleans can be integers: True = 1, False = 0
 
 # failing
 fail_check_string = isinstance(a_string, bool)
 fail_check_integer = isinstance(an_integer, float)
-fail_check_float = isinstance(a_float, str)
-fail_check_boolean = isinstance(a_boolean, int)
+fail_check_float = isinstance(a_float, int)
+fail_check_boolean = isinstance(a_boolean, str)
 
 print("end of script")


### PR DESCRIPTION
Python treats Booleans as a subclass of integers, where `True = 1` and `False = 0`. This behavior caused unexpected results in the "02_data_types.py" example when testing `isinstance(a_boolean, int)`. The original code expected the `fail_check_boolean` variable to store `False`, but it returned `True` because of this underlying behavior.

Changes made:

1. Added a separate check for `isinstance(a_boolean, int)` to properly identify the Boolean as an integer.
2. Adjusted failing checks to test `a_boolean` against unrelated types (e.g., `str`).